### PR TITLE
Update terminology and remove header

### DIFF
--- a/dist/assets/iframe.html
+++ b/dist/assets/iframe.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8">
-    <title>Iframe App Template</title>
+    <title>App Scaffold</title>
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/bootstrap/2.3.2/css/bootstrap.min.css">
     <link rel="stylesheet" href="main.css">
   </head>

--- a/dist/assets/iframe.html
+++ b/dist/assets/iframe.html
@@ -9,7 +9,7 @@
   <body>
     <section data-main></section>
     <script src="https://cdn.jsdelivr.net/g/lodash@4.3.0,handlebarsjs@4.0.5,jquery@2.2.0,momentjs@2.9.0,bootstrap@2.3.2"></script>
-    <script src="https://assets.zendesk.com/apps/sdk/2.0.0-beta1/zaf_sdk.js"></script>
+    <script src="https://assets.zendesk.com/apps/sdk/2.0.0-beta3/zaf_sdk.js"></script>
     <script src="main.js"></script>
   </body>
 </html>

--- a/dist/manifest.json
+++ b/dist/manifest.json
@@ -1,5 +1,5 @@
 {
-  "name": "Iframe App Template",
+  "name": "App Scaffold",
   "author": {
     "name": "Zendesk",
     "email": "support@zendesk.com",

--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
-  "name": "iframe_app_template",
+  "name": "app_scaffold",
   "version": "0.0.1",
-  "description": "A template for developers to build iframe only apps",
+  "description": "A scaffold for developers to build ZAF v2 apps",
   "repository": {
     "type": "git",
-    "url": "https://github.com/zendesk/iframe_app_template.git"
+    "url": "https://github.com/zendesk/app_scaffold.git"
   },
   "scripts": {
     "build": "webpack -p",
@@ -18,7 +18,7 @@
     "framework"
   ],
   "bugs": {
-    "url": "https://github.com/zendesk/iframe_app_template/issues"
+    "url": "https://github.com/zendesk/app_scaffold/issues"
   },
   "devDependencies": {
     "babel-core": "^6.5.2",

--- a/src/javascripts/legacy_app.js
+++ b/src/javascripts/legacy_app.js
@@ -11,7 +11,7 @@ var App = {
   },
 
   events: {
-    'app.activated': 'init',
+    'app.created': 'init',
     'getMe.done': 'renderMain'
   },
 

--- a/src/templates/main.hdbs
+++ b/src/templates/main.hdbs
@@ -1,2 +1,1 @@
-<h3>{{setting "title"}}</h3>
 <p>Hello {{name}}!</p>


### PR DESCRIPTION
:v:

/cc @zendesk/vegemite

Now Lotus supplies a header we can remove it from the template.

### Risks
* None