### PR TITLE
Using Handlebars with webpack warning require.extentions not supported

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -71,7 +71,8 @@ module.exports = {
   resolve: {
     modulesDirectories: [ 'node_modules', './lib/javascripts' ],
     alias: {
-      'app_manifest': path.join(__dirname, './dist/manifest.json')
+      'app_manifest': path.join(__dirname, './dist/manifest.json'),
+      handlebars: 'handlebars/dist/handlebars.min.js'
     },
     extensions: ['', '.js']
   },


### PR DESCRIPTION
Add alias for handlebars that fixes #25