### PR TITLE
[AF-458] Use external Handlebars runtime in translations and fix warning

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -93,7 +93,7 @@ module.exports = {
       warning: 'AUTOMATICALLY GENERATED FROM ./lib/templates/layout.hdbs - DO NOT MODIFY THIS FILE DIRECTLY',
       vendorCss: externalAssets.css,
       vendorJs: externalAssets.js,
-      template: './lib/templates/layout.hdbs'
+      template: '!!handlebars!./lib/templates/layout.hdbs'
     }),
     new webpack.optimize.UglifyJsPlugin({
       compress: {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -45,7 +45,10 @@ module.exports = {
       },
       {
         test: /src\/translations\/.*\.json/,
-        loader: 'translations-loader'
+        loader: 'translations-loader',
+        query: {
+          runtime: 'handlebars'
+        }
       },
       {
         test: /\.js$/,


### PR DESCRIPTION
:v:

/cc @zendesk/vegemite

### Description

#12 accidentally ended-up causing Webpack to include the Handlebars runtime compiled into the main.js, even though it was loaded externally from the CDN. This PR adds the correct `runtime` query parameter to the loader to it overrides including Handlebars and shaves ~7kB off the compiled JS size.

Also fixes #25, which was being caused by the HtmlWebpackPlugin having a .hdbs template. This was loading the handlebars-loader since it matched the /.hbds/ regex, and was telling the loader to use "handlebars" as the runtime, which is normally mapped to the external handlebars, but in the  HtmlWebpackPlugin env it instead is mapping to the node module of the same name. The node_module has some magic in it to try and use require.extension, which isn't supported, and hence the warning. The fix is to force the loader for the template to use the handlebars-loader without a custom runtime, which instead loads handlebars/runtime.js. 

### References
* JIRA: https://zendesk.atlassian.net/browse/AF-458

### Risks
* low: translations could break
* low: templates could break
* low: html could break