### PR TITLE
Replace bootstrap with Zendesk Garden css

### DIFF
--- a/src/stylesheets/app.scss
+++ b/src/stylesheets/app.scss
@@ -1,1 +1,5 @@
 @import './ticket_sidebar.scss';
+
+body {
+  margin: 0;
+}

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -7,10 +7,10 @@ var HtmlWebpackPlugin = require('html-webpack-plugin');
 
 var externalAssets = {
   css: [
-    'https://cdn.jsdelivr.net/bootstrap/3.3.7/css/bootstrap.min.css'
+    'https://assets.zendesk.com/apps/sdk-assets/css/0/zendesk_garden.css'
   ],
   js: [
-    'https://cdn.jsdelivr.net/g/lodash@4.14.0,handlebarsjs@4.0.5,jquery@3.1.0,bootstrap@3.3.7,momentjs@2.14.1',
+    'https://cdn.jsdelivr.net/g/lodash@4.14.0,handlebarsjs@4.0.5,jquery@3.1.0',
     'https://assets.zendesk.com/apps/sdk/2.0/zaf_sdk.js'
   ]
 }


### PR DESCRIPTION
:v:

/cc @zendesk/vegemite @zendesk/zdbreaking 

### Description

Replace Bootstrap with Zendesk Garden CSS.

Although this is a breaking change, the idea of how developers consume this code is that they create a copy of it, as such this should only affect new developers creating new apps (hence the from-scratch branch).

![screen shot 2017-01-04 at 4 41 56 pm](https://cloud.githubusercontent.com/assets/153219/21632692/d4e2cd78-d29c-11e6-9bd8-2344dfd29a0e.png)

### References
* JIRA: https://zendesk.atlassian.net/browse/AF-452