### PR TITLE
[FROM-SCRATCH] Fix handlebars image requires

### DIFF
--- a/src/templates/loading.hdbs
+++ b/src/templates/loading.hdbs
@@ -1,1 +1,1 @@
-<img src="spinner.gif" alt="loading..." />
+<img src="../images/spinner.gif" alt="loading..." />

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -68,7 +68,8 @@ module.exports = {
         loader: 'handlebars-loader',
         query: {
           extensions: ['handlebars', 'hdbs', 'hbs'],
-          runtime: 'handlebars'
+          runtime: 'handlebars',
+          inlineRequires: '\/images\/'
         }
       }
     ]


### PR DESCRIPTION
Using the `from-scratch` branch, webpack didn't bundle any images referenced inside handlebar templates, so I got a console error right away that spinner.gif wasn't found.

[Seems the issue is the handlebars-loader](https://github.com/pcardune/handlebars-loader/issues/37).

I added inlineRequires option which fixed it, and the loading template shipped in the scaffold was updated to make it work. The path format ../images/ is the same format as when referencing images in stylesheets.