### PR TITLE
Fix missing translation issue for apps using the Zendesk translation format

### DIFF
--- a/lib/javascripts/i18n.js
+++ b/lib/javascripts/i18n.js
@@ -22,7 +22,7 @@ const I18n = Object.freeze({
     if (keyType !== 'string') {
       throw new Error(`Translation key must be a string, got: ${keyType}`);
     }
-    var template = translations[key];
+    var template = translations[key] || translations[`${key}.value`];
     if (!template) {
       throw new Error(`Missing translation: ${key}`);
     }


### PR DESCRIPTION
cc @zendesk/vegemite 

## References
- https://support.zendesk.com/hc/en-us/community/posts/115007133228--BUG-Missing-translation?page=1