### PR TITLE
Getter for settings

### DIFF
--- a/lib/javascripts/base_app.js
+++ b/lib/javascripts/base_app.js
@@ -230,7 +230,7 @@ BaseApp.extend = function(appPrototype) {
   // direct access of the object underlying the setting API. See
   // https://developer.zendesk.com/apps/docs/agent/data#setting
   // we define this property after extending BaseApp so that the
-  // accessor won't be called before the app is instanciated
+  // accessor won't be called before the app is instantiated
   Object.defineProperty(App.prototype, "settings", {
     get() {
       return this._metadata.settings;

--- a/lib/javascripts/base_app.js
+++ b/lib/javascripts/base_app.js
@@ -226,6 +226,11 @@ BaseApp.extend = function(appPrototype) {
 
   App.prototype = _.extend({}, BaseApp.prototype, appPrototype);
 
+  // settings is an alias provided so that any apps that attempt
+  // direct access of the object underlying the setting API. See
+  // https://developer.zendesk.com/apps/docs/agent/data#setting
+  // we define this property after extending BaseApp so that the
+  // accessor won't be called before the app is instanciated
   Object.defineProperty(App.prototype, "settings", {
     get() {
       return this._metadata.settings;

--- a/lib/javascripts/base_app.js
+++ b/lib/javascripts/base_app.js
@@ -226,6 +226,12 @@ BaseApp.extend = function(appPrototype) {
 
   App.prototype = _.extend({}, BaseApp.prototype, appPrototype);
 
+  Object.defineProperty(App.prototype, "settings", {
+    get() {
+      return this._metadata.settings;
+    }
+  });
+
   return App;
 };
 


### PR DESCRIPTION
✌️ 

/cc @zendesk/vegemite 

### Overview

The `settings` object backs the `setting` API.  The object is unofficial, but commonly used directly in v1 apps, even some Built by Zendesk apps.  This simply maps the getter to _metadata.settings` to prevent exceptions.

Note: The reason for using `Object.defineProperty` in this way is that, if defining the accessor on the prototype earlier (with other shims), the accessor will be called when Underscore's `extend` function is used.  In this scenario, an exception is thrown for the attempted access of `this._metadata` before it has been set.

### Risks
- [N/A] The object _is_ already directly accessible at `this._metadata.settings`
