### PR TITLE
Rename @zendesk/i18n -> @zendesk/localization

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -31,7 +31,7 @@ Anyone specific?
 Unless there's a good reason not to:
 @zendesk/apps-migration
 If translation-related:
-@zendesk/i18n
+@zendesk/localization
 
 ## Risks
 * [HIGH | medium | low] Does it work across browsers (including IE!)?


### PR DESCRIPTION
## Description
@zendesk/localization is responsible for English string reviews. @zendesk/i18n is for Engineering support (issues with String Sweep, etc).

## CCs
@zendesk/apps-migration @zendesk/i18n

## Risks
* None. GitHub PR template change.