### PR TITLE
Fixed Jest coverage issue

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,3 +1,8 @@
 {
-  "presets": ["env"]
+  "presets": ["@babel/preset-env"],
+  "plugins": [["@babel/plugin-transform-runtime",
+    {
+      "regenerator": true
+    }
+  ]]
 }

--- a/package.json
+++ b/package.json
@@ -21,6 +21,8 @@
     "start": "zat server -p ./dist --unattended"
   },
   "devDependencies": {
+    "@babel/core": "^7.13.15",
+    "@babel/plugin-transform-runtime": "^7.13.15",
     "@zendeskgarden/css-arrows": "^3.1.1",
     "@zendeskgarden/css-avatars": "^3.0.3",
     "@zendeskgarden/css-bedrock": "^7.0.3",
@@ -36,8 +38,8 @@
     "@zendeskgarden/css-tags": "^4.0.4",
     "@zendeskgarden/css-tooltips": "^4.0.4",
     "@zendeskgarden/css-utilities": "^3.0.1",
-    "babel-core": "^6.26.3",
-    "babel-jest": "^23.4.0",
+    "babel-core": "^7.0.0-bridge.0",
+    "babel-jest": "^23.6.0",
     "babel-loader": "^7.1.5",
     "babel-polyfill": "^6.26.0",
     "babel-preset-env": "^1.7.0",
@@ -45,7 +47,6 @@
     "copy-webpack-plugin": "^4.5.2",
     "css-loader": "^1.0.0",
     "html-webpack-plugin": "^3.2.0",
-    "jest": "^23.4.0",
     "mini-css-extract-plugin": "^0.4.1",
     "postcss-import": "^11.1.0",
     "postcss-loader": "^2.1.6",
@@ -53,7 +54,10 @@
     "precss": "^3.1.2",
     "standard": "^11.0.1",
     "webpack": "^4.16.0",
-    "webpack-cli": "^3.0.8"
+    "webpack-cli": "^3.0.8",
+    "@babel/preset-env": "^7.13.15",
+    "@babel/runtime": "^7.13.10",
+    "jest": "^26.6.3"
   },
   "dependencies": {}
 }


### PR DESCRIPTION
Fixed issue with Jest coverage not showing data

## Description
When executing the test with Jest on app_scaffold with the flag --coverage, we get the coverage index.html file generated but all the percentages values and color bars are empty.

## Screenshots (if needed)
<details>
<summary>Jest coverage with not showing data</summary>
<img src="https://user-images.githubusercontent.com/10067295/114717954-dce8bd80-9d35-11eb-9b3e-efe3ae9f37c3.png" width="800" />
</details>

## CCs
@zendesk/vegemite
