### PR TITLE
[VEG-601] Support flexible: true default option in ZAT tooling

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -10,7 +10,8 @@
   "location": {
     "support": {
       "ticket_sidebar": {
-        "url": "assets/iframe.html"
+        "url": "assets/iframe.html",
+        "flexible": true
       }
     }
   },


### PR DESCRIPTION
@zendesk/vegemite 

## Description
Flexible apps are coming, therefore, we should support this new functionality in the ZAT tooling.  ZAT references this scaffold when bootstrapping a new app via `zat new`, so let's update things here accordingly.

## Tasks
- [ ] Write tests

## References
[VEG-601](https://zendesk.atlassian.net/browse/VEG-601)

## Risks
* Low. Might not support flexible apps properly in the legacy ZAT tooling.