### PR TITLE
Clearly indicate that this is no longer current

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
+
 *Use of this software is subject to important terms and conditions as set forth in the License file*
 
-# App Scaffold
+# 🚩 DEPRECATED 🚩 App Scaffold. 
+
+This Scaffold is no longer supported.  Instead see [zendesk/app_scaffolds](https://github.com/zendesk/app_scaffolds)
 
 ## Description
 This repo contains a scaffold to help developers build [apps for Zendesk products](https://developer.zendesk.com/apps/docs/apps-v2/getting_started).


### PR DESCRIPTION
# Deprecation Notice and redirect to current scaffolds

## Description
This Repo hasn't been significantly updated since 2017

Real changes are happening over at [zendesk/app_scaffolds](https://github.com/zendesk/app_scaffolds).

It would be awesome to make that really clear in this repo, so people don't get confused.
